### PR TITLE
Require quorum equal to number of nodes

### DIFF
--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/Configuration.java
@@ -334,7 +334,7 @@ public class Configuration {
         args.add("--default.discovery.zen.fd.ping_interval=1s");
         args.add("--default.discovery.zen.fd.ping_retries=30");
         args.add("--default.discovery.zen.ping.multicast.enabled=false");
-
+        args.add("--default.discovery.zen.minimum_master_nodes=" + getElasticsearchNodes());
 
         return args;
     }

--- a/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategy.java
+++ b/scheduler/src/main/java/org/apache/mesos/elasticsearch/scheduler/OfferStrategy.java
@@ -39,7 +39,10 @@ public class OfferStrategy {
                 // TODO (PNW): Better get HTTP address method. We do this everywhere.
                 InetSocketAddress clientAddress = taskList.get(clusterState.getTaskList().get(0).getTaskId().getValue()).getClientAddress();
                 String hostAddress = NetworkUtils.addressToString(clientAddress, configuration.getIsUseIpAddress());
-                return Unirest.get(hostAddress).asString().getStatus() == 200;
+                final int hostHttpStatus = Unirest.get(hostAddress).asString().getStatus();
+                // If the quorum requirement is set higher than the number of nodes running,
+                // we will get back a 503.
+                return hostHttpStatus == 200 || hostHttpStatus == 503;
             } catch (UnirestException e) {
                 return false;
             }


### PR DESCRIPTION
This is an ugly way to do it, since it won't allow for changing the
number of nodes in the cluster. However, this is better than having
a quorum of 1, thus allowing split-brain clusters.

Note: This PR is against a fork of the `mesos-elasticsearch` framework we've been using.
